### PR TITLE
Add autoconf to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -sSf https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN cat /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update
-RUN apt-get install gcc make libssl-dev pkg-config postgresql-13 postgresql-server-dev-13 -y
+RUN apt-get install gcc make libssl-dev autoconf pkg-config postgresql-13 postgresql-server-dev-13 -y
 
 COPY . /citus
 


### PR DESCRIPTION
This error shows up on Docker for Mac, but not on Linux:

```
 > [11/11] RUN cd /citus/src/backend/columnar && DESTDIR=/pg_ext make install:
#16 0.168 cd /citus && ./autogen.sh
#16 0.169 ./autogen.sh: line 7: autoreconf: command not found
#16 0.170 make: *** [/citus/configure] Error 127
#16 0.170 ../../../Makefile.global:69: recipe for target '/citus/configure' failed
```
