### PR TITLE
make install scripts idempotent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,9 @@ RUN curl -sSf https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN cat /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update
-RUN apt-get install gcc make libssl-dev autoconf pkg-config postgresql-13 postgresql-server-dev-13 -y
+RUN apt-get install gcc make libssl-dev autoconf pkg-config postgresql-13 postgresql-server-dev-13 libcurl4-gnutls-dev liblz4-dev libzstd-dev -y
 
 COPY . /citus
 
-RUN apt-get install libcurl4-gnutls-dev liblz4-dev libzstd-dev -y
 RUN cd /citus && ./configure
 RUN cd /citus/src/backend/columnar && DESTDIR=/pg_ext make install

--- a/src/backend/columnar/sql/columnar--10.0-3--10.1-1.sql
+++ b/src/backend/columnar/sql/columnar--10.0-3--10.1-1.sql
@@ -6,17 +6,17 @@ DO $proc$
 BEGIN
 IF substring(current_Setting('server_version'), '\d+')::int >= 12 THEN
   EXECUTE $$
-ALTER TABLE columnar.chunk DROP CONSTRAINT chunk_storage_id_stripe_num_chunk_group_num_fkey;
-ALTER TABLE columnar.chunk_group DROP CONSTRAINT chunk_group_storage_id_stripe_num_fkey;
+ALTER TABLE columnar.chunk DROP CONSTRAINT IF EXISTS chunk_storage_id_stripe_num_chunk_group_num_fkey;
+ALTER TABLE columnar.chunk_group DROP CONSTRAINT IF EXISTS chunk_group_storage_id_stripe_num_fkey;
   $$;
 ELSE
   EXECUTE $$
-ALTER TABLE columnar.chunk DROP CONSTRAINT chunk_storage_id_fkey;
-ALTER TABLE columnar.chunk_group DROP CONSTRAINT chunk_group_storage_id_fkey;
+ALTER TABLE columnar.chunk DROP CONSTRAINT IF EXISTS chunk_storage_id_fkey;
+ALTER TABLE columnar.chunk_group DROP CONSTRAINT IF EXISTS chunk_group_storage_id_fkey;
   $$;
 END IF;
 END$proc$;
 
 -- since we dropped pg11 support, we don't need to worry about missing
 -- columnar objects when upgrading postgres
-DROP FUNCTION columnar.columnar_ensure_objects_exist();
+DROP FUNCTION IF EXISTS columnar.columnar_ensure_objects_exist();

--- a/src/backend/columnar/sql/columnar--10.1-1--10.2-1.sql
+++ b/src/backend/columnar/sql/columnar--10.1-1--10.2-1.sql
@@ -3,8 +3,8 @@
 -- For a proper mapping between tid & (stripe, row_num), add a new column to
 -- columnar.stripe and define a BTREE index on this column.
 -- Also include storage_id column for per-relation scans.
-ALTER TABLE columnar.stripe ADD COLUMN first_row_number bigint;
-CREATE INDEX stripe_first_row_number_idx ON columnar.stripe USING BTREE(storage_id, first_row_number);
+ALTER TABLE columnar.stripe ADD COLUMN IF NOT EXISTS first_row_number bigint;
+CREATE INDEX IF NOT EXISTS stripe_first_row_number_idx ON columnar.stripe USING BTREE(storage_id, first_row_number);
 
 -- Populate first_row_number column of columnar.stripe table.
 --

--- a/src/backend/columnar/sql/columnar--10.2-2--10.2-3.sql
+++ b/src/backend/columnar/sql/columnar--10.2-2--10.2-3.sql
@@ -10,6 +10,7 @@
 --
 -- To do that, drop stripe_first_row_number_idx and create a unique
 -- constraint with the same name to keep the code change at minimum.
-DROP INDEX columnar.stripe_first_row_number_idx;
+DROP INDEX IF EXISTS columnar.stripe_first_row_number_idx;
+ALTER TABLE columnar.stripe DROP CONSTRAINT IF EXISTS stripe_first_row_number_idx;
 ALTER TABLE columnar.stripe ADD CONSTRAINT stripe_first_row_number_idx
 UNIQUE (storage_id, first_row_number);

--- a/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
+++ b/src/backend/columnar/sql/columnar--9.5-1--10.0-1.sql
@@ -1,11 +1,11 @@
 -- columnar--9.5-1--10.0-1.sql
 
-CREATE SCHEMA columnar;
+CREATE SCHEMA IF NOT EXISTS columnar;
 SET search_path TO columnar;
 
-CREATE SEQUENCE storageid_seq MINVALUE 10000000000 NO CYCLE;
+CREATE SEQUENCE IF NOT EXISTS storageid_seq MINVALUE 10000000000 NO CYCLE;
 
-CREATE TABLE options (
+CREATE TABLE IF NOT EXISTS options (
     regclass regclass NOT NULL PRIMARY KEY,
     chunk_group_row_limit int NOT NULL,
     stripe_row_limit int NOT NULL,
@@ -15,7 +15,7 @@ CREATE TABLE options (
 
 COMMENT ON TABLE options IS 'columnar table specific options, maintained by alter_columnar_table_set';
 
-CREATE TABLE stripe (
+CREATE TABLE IF NOT EXISTS stripe (
     storage_id bigint NOT NULL,
     stripe_num bigint NOT NULL,
     file_offset bigint NOT NULL,
@@ -29,7 +29,7 @@ CREATE TABLE stripe (
 
 COMMENT ON TABLE stripe IS 'Columnar per stripe metadata';
 
-CREATE TABLE chunk_group (
+CREATE TABLE IF NOT EXISTS chunk_group (
     storage_id bigint NOT NULL,
     stripe_num bigint NOT NULL,
     chunk_group_num int NOT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE chunk_group (
 
 COMMENT ON TABLE chunk_group IS 'Columnar chunk group metadata';
 
-CREATE TABLE chunk (
+CREATE TABLE IF NOT EXISTS chunk (
     storage_id bigint NOT NULL,
     stripe_num bigint NOT NULL,
     attr_num int NOT NULL,


### PR DESCRIPTION
This allows a renamed library to be installed "over" an existing install.

Note that ALTER TABLE ... ADD CONSTRAINT does not support 'IF NOT EXISTS',
thus the constraint is dropped and re-added. This will revalidate the
constraint, but this should take a trivial amount of time as the metadata
tables are generally very small. Alternatively, NOT VALID could be added
to this command with a VALIDATE CONSTRAINT to be called later.