### PR TITLE
[HYD-148] Add `columnar.` ns to `alter_columnar_table_set` & `alter_columnar_table_reset`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  workflow_dispatch:
+  push:
+
+jobs:
+  docker_build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Docker Build
+        run: ./docker-build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,23 @@ RUN curl -sSf https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
 RUN cat /etc/apt/sources.list.d/pgdg.list
 RUN apt-get update
-RUN apt-get install gcc make libssl-dev autoconf pkg-config postgresql-13 postgresql-server-dev-13 -y
+RUN apt-get install gcc make libssl-dev autoconf pkg-config postgresql-13 postgresql-server-dev-13 libcurl4-gnutls-dev liblz4-dev libzstd-dev -y
 
 COPY . /citus
+RUN chown -R postgres:postgres /citus
 
-RUN apt-get install libcurl4-gnutls-dev liblz4-dev libzstd-dev -y
-RUN cd /citus && ./configure
-RUN cd /citus/src/backend/columnar && DESTDIR=/pg_ext make install
+# install into this postgres so we can run tests
+USER postgres
+WORKDIR /citus
+ENV PATH=/usr/lib/postgresql/13/bin:$PATH
+RUN ./configure && make clean extension
+
+USER root
+RUN make install-all
+
+USER postgres
+RUN make check-all
+
+# tests passed, so export extension into /pg_ext
+USER root
+RUN DESTDIR=/pg_ext make -C /citus/src/backend/columnar install

--- a/src/backend/columnar/columnar.control
+++ b/src/backend/columnar/columnar.control
@@ -1,5 +1,5 @@
 # Citus extension
 comment = 'Citus Columnar extension'
-default_version = '11.1-2'
+default_version = '11.1-3'
 module_pathname = '$libdir/columnar'
 relocatable = false

--- a/src/backend/columnar/sql/columnar--11.1-2--11.1-3.sql
+++ b/src/backend/columnar/sql/columnar--11.1-2--11.1-3.sql
@@ -1,0 +1,4 @@
+-- columnar--11.1-1--11.2-1.sql
+
+#include "udfs/alter_columnar_table_set/11.1-3.sql"
+#include "udfs/alter_columnar_table_reset/11.1-3.sql"

--- a/src/backend/columnar/sql/downgrades/columnar--11.1-3--11.1-2.sql
+++ b/src/backend/columnar/sql/downgrades/columnar--11.1-3--11.1-2.sql
@@ -1,0 +1,4 @@
+-- columnar--11.1-3--11.1-2.sql
+
+#include "udfs/alter_columnar_table_set/11.1-2.sql"
+#include "udfs/alter_columnar_table_reset/11.1-2.sql"

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_reset/11.1-2.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_reset/11.1-2.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION columnar.alter_columnar_table_reset(
+DROP FUNCTION IF EXISTS columnar.alter_columnar_table_reset;
+
+CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
     chunk_group_row_limit bool DEFAULT false,
     stripe_row_limit bool DEFAULT false,
@@ -8,7 +10,7 @@ CREATE OR REPLACE FUNCTION columnar.alter_columnar_table_reset(
     LANGUAGE C
 AS 'MODULE_PATHNAME', 'alter_columnar_table_reset';
 
-COMMENT ON FUNCTION columnar.alter_columnar_table_reset(
+COMMENT ON FUNCTION pg_catalog.alter_columnar_table_reset(
     table_name regclass,
     chunk_group_row_limit bool,
     stripe_row_limit bool,

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_reset/11.1-3.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_reset/11.1-3.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS pg_catalog.alter_columnar_table_reset;
+
 CREATE OR REPLACE FUNCTION columnar.alter_columnar_table_reset(
     table_name regclass,
     chunk_group_row_limit bool DEFAULT false,

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_set/11.1-2.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_set/11.1-2.sql
@@ -1,4 +1,6 @@
-CREATE OR REPLACE FUNCTION columnar.alter_columnar_table_set(
+DROP FUNCTION IF EXISTS columnar.alter_columnar_table_set;
+
+CREATE OR REPLACE FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
     chunk_group_row_limit int DEFAULT NULL,
     stripe_row_limit int DEFAULT NULL,
@@ -8,7 +10,7 @@ CREATE OR REPLACE FUNCTION columnar.alter_columnar_table_set(
     LANGUAGE C
 AS 'MODULE_PATHNAME', 'alter_columnar_table_set';
 
-COMMENT ON FUNCTION columnar.alter_columnar_table_set(
+COMMENT ON FUNCTION pg_catalog.alter_columnar_table_set(
     table_name regclass,
     chunk_group_row_limit int,
     stripe_row_limit int,

--- a/src/backend/columnar/sql/udfs/alter_columnar_table_set/11.1-3.sql
+++ b/src/backend/columnar/sql/udfs/alter_columnar_table_set/11.1-3.sql
@@ -1,3 +1,5 @@
+DROP FUNCTION IF EXISTS pg_catalog.alter_columnar_table_set;
+
 CREATE OR REPLACE FUNCTION columnar.alter_columnar_table_set(
     table_name regclass,
     chunk_group_row_limit int DEFAULT NULL,

--- a/src/test/regress/expected/columnar_create.out
+++ b/src/test/regress/expected/columnar_create.out
@@ -5,7 +5,7 @@
 CREATE TABLE contestant (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
 	USING columnar;
-SELECT alter_columnar_table_set('contestant', compression => 'none');
+SELECT columnar.alter_columnar_table_set('contestant', compression => 'none');
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/expected/columnar_empty.out
+++ b/src/test/regress/expected/columnar_empty.out
@@ -5,19 +5,19 @@ SET columnar.compression to 'none';
 create table t_uncompressed(a int) using columnar;
 create table t_compressed(a int) using columnar;
 -- set options
-SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('t_compressed', compression => 'pglz');
  alter_columnar_table_set 
 --------------------------
  
 (1 row)
 
-SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 2000);
+SELECT columnar.alter_columnar_table_set('t_compressed', stripe_row_limit => 2000);
  alter_columnar_table_set 
 --------------------------
  
 (1 row)
 
-SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('t_compressed', chunk_group_row_limit => 1000);
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/expected/columnar_fallback_scan.out
+++ b/src/test/regress/expected/columnar_fallback_scan.out
@@ -8,7 +8,7 @@
 set columnar.enable_custom_scan = false;
 create table fallback_scan(i int) using columnar;
 -- large enough to test parallel_workers > 1
-select alter_columnar_table_set('fallback_scan', compression => 'none');
+select columnar.alter_columnar_table_set('fallback_scan', compression => 'none');
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/expected/columnar_first_row_number.out
+++ b/src/test/regress/expected/columnar_first_row_number.out
@@ -7,7 +7,7 @@ BEGIN;
   INSERT INTO col_table_1 SELECT i FROM generate_series(1, 11) i;
 ROLLBACK;
 INSERT INTO col_table_1 SELECT i FROM generate_series(1, 12) i;
-SELECT alter_columnar_table_set('col_table_1', stripe_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('col_table_1', stripe_row_limit => 1000);
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/expected/columnar_insert.out
+++ b/src/test/regress/expected/columnar_insert.out
@@ -173,7 +173,7 @@ DROP TABLE test_toast_columnar;
 -- We support writing into zero column tables, but not reading from them.
 -- We test that metadata makes sense so we can fix the read path in future.
 CREATE TABLE zero_col() USING columnar;
-SELECT alter_columnar_table_set('zero_col', chunk_group_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('zero_col', chunk_group_row_limit => 1000);
  alter_columnar_table_set 
 --------------------------
  
@@ -233,7 +233,7 @@ ORDER BY 1,2,3,4;
 (5 rows)
 
 CREATE TABLE selfinsert(x int) USING columnar;
-SELECT alter_columnar_table_set('selfinsert', stripe_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('selfinsert', stripe_row_limit => 1000);
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/expected/columnar_matview.out
+++ b/src/test/regress/expected/columnar_matview.out
@@ -32,7 +32,7 @@ WHERE regclass = 't_view'::regclass;
 (1 row)
 
 -- show we can set options on a materialized view
-SELECT alter_columnar_table_set('t_view', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('t_view', compression => 'pglz');
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/expected/columnar_tableoptions.out
+++ b/src/test/regress/expected/columnar_tableoptions.out
@@ -149,7 +149,7 @@ WHERE regclass = 'table_options'::regclass;
  table_options |                  4000 |             8000 |                 7 | none
 (1 row)
 
-SELECT alter_columnar_table_reset('table_options', chunk_group_row_limit => true);
+SELECT columnar.alter_columnar_table_reset('table_options', chunk_group_row_limit => true);
  alter_columnar_table_reset 
 ----------------------------
  
@@ -163,7 +163,7 @@ WHERE regclass = 'table_options'::regclass;
  table_options |                  1000 |             8000 |                 7 | none
 (1 row)
 
-SELECT alter_columnar_table_reset('table_options', stripe_row_limit => true);
+SELECT columnar.alter_columnar_table_reset('table_options', stripe_row_limit => true);
  alter_columnar_table_reset 
 ----------------------------
  
@@ -177,7 +177,7 @@ WHERE regclass = 'table_options'::regclass;
  table_options |                  1000 |            10000 |                 7 | none
 (1 row)
 
-SELECT alter_columnar_table_reset('table_options', compression => true);
+SELECT columnar.alter_columnar_table_reset('table_options', compression => true);
  alter_columnar_table_reset 
 ----------------------------
  
@@ -191,7 +191,7 @@ WHERE regclass = 'table_options'::regclass;
  table_options |                  1000 |            10000 |                 7 | pglz
 (1 row)
 
-SELECT alter_columnar_table_reset('table_options', compression_level => true);
+SELECT columnar.alter_columnar_table_reset('table_options', compression_level => true);
  alter_columnar_table_reset 
 ----------------------------
  
@@ -218,7 +218,7 @@ WHERE regclass = 'table_options'::regclass;
  table_options |                  1000 |            10000 |                11 | pglz
 (1 row)
 
-SELECT alter_columnar_table_reset(
+SELECT columnar.alter_columnar_table_reset(
     'table_options',
     chunk_group_row_limit => true,
     stripe_row_limit => true,
@@ -242,7 +242,7 @@ WHERE regclass = 'table_options'::regclass;
 CREATE TABLE not_a_columnar_table (a int);
 SELECT columnar.alter_columnar_table_set('not_a_columnar_table', compression => 'pglz');
 ERROR:  table not_a_columnar_table is not a columnar table
-SELECT alter_columnar_table_reset('not_a_columnar_table', compression => true);
+SELECT columnar.alter_columnar_table_reset('not_a_columnar_table', compression => true);
 ERROR:  table not_a_columnar_table is not a columnar table
 -- verify you can't use a compression that is not known
 SELECT columnar.alter_columnar_table_set('table_options', compression => 'foobar');

--- a/src/test/regress/expected/columnar_tableoptions.out
+++ b/src/test/regress/expected/columnar_tableoptions.out
@@ -12,7 +12,7 @@ WHERE regclass = 'table_options'::regclass;
 (1 row)
 
 -- test changing the compression
-SELECT alter_columnar_table_set('table_options', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('table_options', compression => 'pglz');
  alter_columnar_table_set 
 --------------------------
  
@@ -27,7 +27,7 @@ WHERE regclass = 'table_options'::regclass;
 (1 row)
 
 -- test changing the compression level
-SELECT alter_columnar_table_set('table_options', compression_level => 5);
+SELECT columnar.alter_columnar_table_set('table_options', compression_level => 5);
  alter_columnar_table_set 
 --------------------------
  
@@ -42,7 +42,7 @@ WHERE regclass = 'table_options'::regclass;
 (1 row)
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 2000);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 2000);
  alter_columnar_table_set 
 --------------------------
  
@@ -57,7 +57,7 @@ WHERE regclass = 'table_options'::regclass;
 (1 row)
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 4000);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 4000);
  alter_columnar_table_set 
 --------------------------
  
@@ -82,7 +82,7 @@ WHERE regclass = 'table_options'::regclass;
 (1 row)
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 8000, chunk_group_row_limit => 4000, compression => 'none', compression_level => 7);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 8000, chunk_group_row_limit => 4000, compression => 'none', compression_level => 7);
  alter_columnar_table_set 
 --------------------------
  
@@ -240,34 +240,34 @@ WHERE regclass = 'table_options'::regclass;
 -- verify edge cases
 -- first start with a table that is not a columnar table
 CREATE TABLE not_a_columnar_table (a int);
-SELECT alter_columnar_table_set('not_a_columnar_table', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('not_a_columnar_table', compression => 'pglz');
 ERROR:  table not_a_columnar_table is not a columnar table
 SELECT alter_columnar_table_reset('not_a_columnar_table', compression => true);
 ERROR:  table not_a_columnar_table is not a columnar table
 -- verify you can't use a compression that is not known
-SELECT alter_columnar_table_set('table_options', compression => 'foobar');
+SELECT columnar.alter_columnar_table_set('table_options', compression => 'foobar');
 ERROR:  unknown compression type for columnar table: foobar
 -- verify cannot set out of range compression levels
-SELECT alter_columnar_table_set('table_options', compression_level => 0);
+SELECT columnar.alter_columnar_table_set('table_options', compression_level => 0);
 ERROR:  compression level out of range
 HINT:  compression level must be between 1 and 19
-SELECT alter_columnar_table_set('table_options', compression_level => 20);
+SELECT columnar.alter_columnar_table_set('table_options', compression_level => 20);
 ERROR:  compression level out of range
 HINT:  compression level must be between 1 and 19
 -- verify cannot set out of range stripe_row_limit & chunk_group_row_limit options
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 999);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 999);
 ERROR:  stripe row count limit out of range
 HINT:  stripe row count limit must be between 1000 and 10000000
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 10000001);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 10000001);
 ERROR:  stripe row count limit out of range
 HINT:  stripe row count limit must be between 1000 and 10000000
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 999);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 999);
 ERROR:  chunk group row count limit out of range
 HINT:  chunk group row count limit must be between 1000 and 100000
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 100001);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 100001);
 ERROR:  chunk group row count limit out of range
 HINT:  chunk group row count limit must be between 1000 and 100000
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 0);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 0);
 ERROR:  chunk group row count limit out of range
 HINT:  chunk group row count limit must be between 1000 and 100000
 INSERT INTO table_options VALUES (1);

--- a/src/test/regress/expected/columnar_vacuum.out
+++ b/src/test/regress/expected/columnar_vacuum.out
@@ -62,7 +62,7 @@ select
 (1 row)
 
 -- test the case when all data cannot fit into a single stripe
-SELECT alter_columnar_table_set('t', stripe_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('t', stripe_row_limit => 1000);
  alter_columnar_table_set 
 --------------------------
  
@@ -199,7 +199,7 @@ SELECT count(*) FROM t;
 -- add some stripes with different compression types and create some gaps,
 -- then vacuum to print stats
 BEGIN;
-SELECT alter_columnar_table_set('t',
+SELECT columnar.alter_columnar_table_set('t',
     chunk_group_row_limit => 1000,
     stripe_row_limit => 2000,
     compression => 'pglz');
@@ -212,7 +212,7 @@ SAVEPOINT s1;
 INSERT INTO t SELECT i FROM generate_series(1, 1500) i;
 ROLLBACK TO SAVEPOINT s1;
 INSERT INTO t SELECT i / 5 FROM generate_series(1, 1500) i;
-SELECT alter_columnar_table_set('t', compression => 'none');
+SELECT columnar.alter_columnar_table_set('t', compression => 'none');
  alter_columnar_table_set 
 --------------------------
  
@@ -252,7 +252,7 @@ VACUUM t;
 -- vacuum full should remove chunks for dropped columns
 -- note that, a chunk will be stored in non-compressed for if compression
 -- doesn't reduce its size.
-SELECT alter_columnar_table_set('t', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('t', compression => 'pglz');
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/expected/columnar_zstd.out
+++ b/src/test/regress/expected/columnar_zstd.out
@@ -39,7 +39,7 @@ VACUUM FULL test_zstd;
 SELECT data_length AS size_comp_level_default FROM columnar.stripe WHERE storage_id = (
     SELECT storage_id from columnar_test_helpers.columnar_storage_info('test_zstd')) \gset
 -- change compression level
-SELECT alter_columnar_table_set('test_zstd', compression_level => 19);
+SELECT columnar.alter_columnar_table_set('test_zstd', compression_level => 19);
  alter_columnar_table_set 
 --------------------------
  

--- a/src/test/regress/sql/columnar_create.sql
+++ b/src/test/regress/sql/columnar_create.sql
@@ -6,7 +6,7 @@
 CREATE TABLE contestant (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
 	USING columnar;
-SELECT alter_columnar_table_set('contestant', compression => 'none');
+SELECT columnar.alter_columnar_table_set('contestant', compression => 'none');
 
 CREATE INDEX contestant_idx on contestant(handle);
 

--- a/src/test/regress/sql/columnar_empty.sql
+++ b/src/test/regress/sql/columnar_empty.sql
@@ -7,9 +7,9 @@ create table t_uncompressed(a int) using columnar;
 create table t_compressed(a int) using columnar;
 
 -- set options
-SELECT alter_columnar_table_set('t_compressed', compression => 'pglz');
-SELECT alter_columnar_table_set('t_compressed', stripe_row_limit => 2000);
-SELECT alter_columnar_table_set('t_compressed', chunk_group_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('t_compressed', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('t_compressed', stripe_row_limit => 2000);
+SELECT columnar.alter_columnar_table_set('t_compressed', chunk_group_row_limit => 1000);
 
 SELECT * FROM columnar.options WHERE regclass = 't_compressed'::regclass;
 

--- a/src/test/regress/sql/columnar_fallback_scan.sql
+++ b/src/test/regress/sql/columnar_fallback_scan.sql
@@ -10,7 +10,7 @@ set columnar.enable_custom_scan = false;
 
 create table fallback_scan(i int) using columnar;
 -- large enough to test parallel_workers > 1
-select alter_columnar_table_set('fallback_scan', compression => 'none');
+select columnar.alter_columnar_table_set('fallback_scan', compression => 'none');
 insert into fallback_scan select generate_series(1,150000);
 vacuum analyze fallback_scan;
 

--- a/src/test/regress/sql/columnar_first_row_number.sql
+++ b/src/test/regress/sql/columnar_first_row_number.sql
@@ -12,7 +12,7 @@ ROLLBACK;
 
 INSERT INTO col_table_1 SELECT i FROM generate_series(1, 12) i;
 
-SELECT alter_columnar_table_set('col_table_1', stripe_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('col_table_1', stripe_row_limit => 1000);
 
 INSERT INTO col_table_1 SELECT i FROM generate_series(1, 2350) i;
 

--- a/src/test/regress/sql/columnar_insert.sql
+++ b/src/test/regress/sql/columnar_insert.sql
@@ -119,7 +119,7 @@ DROP TABLE test_toast_columnar;
 -- We support writing into zero column tables, but not reading from them.
 -- We test that metadata makes sense so we can fix the read path in future.
 CREATE TABLE zero_col() USING columnar;
-SELECT alter_columnar_table_set('zero_col', chunk_group_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('zero_col', chunk_group_row_limit => 1000);
 
 INSERT INTO zero_col DEFAULT VALUES;
 INSERT INTO zero_col DEFAULT VALUES;
@@ -157,7 +157,7 @@ ORDER BY 1,2,3,4;
 
 CREATE TABLE selfinsert(x int) USING columnar;
 
-SELECT alter_columnar_table_set('selfinsert', stripe_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('selfinsert', stripe_row_limit => 1000);
 
 BEGIN;
   INSERT INTO selfinsert SELECT generate_series(1,1010);

--- a/src/test/regress/sql/columnar_matview.sql
+++ b/src/test/regress/sql/columnar_matview.sql
@@ -22,7 +22,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
 
 -- show we can set options on a materialized view
-SELECT alter_columnar_table_set('t_view', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('t_view', compression => 'pglz');
 SELECT * FROM columnar.options
 WHERE regclass = 't_view'::regclass;
 

--- a/src/test/regress/sql/columnar_tableoptions.sql
+++ b/src/test/regress/sql/columnar_tableoptions.sql
@@ -10,28 +10,28 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the compression
-SELECT alter_columnar_table_set('table_options', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('table_options', compression => 'pglz');
 
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the compression level
-SELECT alter_columnar_table_set('table_options', compression_level => 5);
+SELECT columnar.alter_columnar_table_set('table_options', compression_level => 5);
 
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 2000);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 2000);
 
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- test changing the chunk_group_row_limit
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 4000);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 4000);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -45,7 +45,7 @@ SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
 -- set all settings at the same time
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 8000, chunk_group_row_limit => 4000, compression => 'none', compression_level => 7);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 8000, chunk_group_row_limit => 4000, compression => 'none', compression_level => 7);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -132,22 +132,22 @@ WHERE regclass = 'table_options'::regclass;
 -- verify edge cases
 -- first start with a table that is not a columnar table
 CREATE TABLE not_a_columnar_table (a int);
-SELECT alter_columnar_table_set('not_a_columnar_table', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('not_a_columnar_table', compression => 'pglz');
 SELECT alter_columnar_table_reset('not_a_columnar_table', compression => true);
 
 -- verify you can't use a compression that is not known
-SELECT alter_columnar_table_set('table_options', compression => 'foobar');
+SELECT columnar.alter_columnar_table_set('table_options', compression => 'foobar');
 
 -- verify cannot set out of range compression levels
-SELECT alter_columnar_table_set('table_options', compression_level => 0);
-SELECT alter_columnar_table_set('table_options', compression_level => 20);
+SELECT columnar.alter_columnar_table_set('table_options', compression_level => 0);
+SELECT columnar.alter_columnar_table_set('table_options', compression_level => 20);
 
 -- verify cannot set out of range stripe_row_limit & chunk_group_row_limit options
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 999);
-SELECT alter_columnar_table_set('table_options', stripe_row_limit => 10000001);
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 999);
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 100001);
-SELECT alter_columnar_table_set('table_options', chunk_group_row_limit => 0);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 999);
+SELECT columnar.alter_columnar_table_set('table_options', stripe_row_limit => 10000001);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 999);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 100001);
+SELECT columnar.alter_columnar_table_set('table_options', chunk_group_row_limit => 0);
 INSERT INTO table_options VALUES (1);
 
 -- verify options are removed when table is dropped

--- a/src/test/regress/sql/columnar_tableoptions.sql
+++ b/src/test/regress/sql/columnar_tableoptions.sql
@@ -85,24 +85,24 @@ SET columnar.compression_level TO 11;
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
-SELECT alter_columnar_table_reset('table_options', chunk_group_row_limit => true);
+SELECT columnar.alter_columnar_table_reset('table_options', chunk_group_row_limit => true);
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
-SELECT alter_columnar_table_reset('table_options', stripe_row_limit => true);
-
--- show table_options settings
-SELECT * FROM columnar.options
-WHERE regclass = 'table_options'::regclass;
-
-SELECT alter_columnar_table_reset('table_options', compression => true);
+SELECT columnar.alter_columnar_table_reset('table_options', stripe_row_limit => true);
 
 -- show table_options settings
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
-SELECT alter_columnar_table_reset('table_options', compression_level => true);
+SELECT columnar.alter_columnar_table_reset('table_options', compression => true);
+
+-- show table_options settings
+SELECT * FROM columnar.options
+WHERE regclass = 'table_options'::regclass;
+
+SELECT columnar.alter_columnar_table_reset('table_options', compression_level => true);
 
 -- show table_options settings
 SELECT * FROM columnar.options
@@ -118,7 +118,7 @@ SET columnar.compression_level TO 13;
 SELECT * FROM columnar.options
 WHERE regclass = 'table_options'::regclass;
 
-SELECT alter_columnar_table_reset(
+SELECT columnar.alter_columnar_table_reset(
     'table_options',
     chunk_group_row_limit => true,
     stripe_row_limit => true,
@@ -133,7 +133,7 @@ WHERE regclass = 'table_options'::regclass;
 -- first start with a table that is not a columnar table
 CREATE TABLE not_a_columnar_table (a int);
 SELECT columnar.alter_columnar_table_set('not_a_columnar_table', compression => 'pglz');
-SELECT alter_columnar_table_reset('not_a_columnar_table', compression => true);
+SELECT columnar.alter_columnar_table_reset('not_a_columnar_table', compression => true);
 
 -- verify you can't use a compression that is not known
 SELECT columnar.alter_columnar_table_set('table_options', compression => 'foobar');

--- a/src/test/regress/sql/columnar_vacuum.sql
+++ b/src/test/regress/sql/columnar_vacuum.sql
@@ -34,7 +34,7 @@ select
   from columnar_test_helpers.columnar_storage_info('t');
 
 -- test the case when all data cannot fit into a single stripe
-SELECT alter_columnar_table_set('t', stripe_row_limit => 1000);
+SELECT columnar.alter_columnar_table_set('t', stripe_row_limit => 1000);
 INSERT INTO t SELECT i, 2 * i FROM generate_series(1,2500) i;
 
 SELECT sum(a), sum(b) FROM t;
@@ -91,7 +91,7 @@ SELECT count(*) FROM t;
 -- then vacuum to print stats
 
 BEGIN;
-SELECT alter_columnar_table_set('t',
+SELECT columnar.alter_columnar_table_set('t',
     chunk_group_row_limit => 1000,
     stripe_row_limit => 2000,
     compression => 'pglz');
@@ -99,7 +99,7 @@ SAVEPOINT s1;
 INSERT INTO t SELECT i FROM generate_series(1, 1500) i;
 ROLLBACK TO SAVEPOINT s1;
 INSERT INTO t SELECT i / 5 FROM generate_series(1, 1500) i;
-SELECT alter_columnar_table_set('t', compression => 'none');
+SELECT columnar.alter_columnar_table_set('t', compression => 'none');
 SAVEPOINT s2;
 INSERT INTO t SELECT i FROM generate_series(1, 1500) i;
 ROLLBACK TO SAVEPOINT s2;
@@ -125,7 +125,7 @@ VACUUM t;
 -- vacuum full should remove chunks for dropped columns
 -- note that, a chunk will be stored in non-compressed for if compression
 -- doesn't reduce its size.
-SELECT alter_columnar_table_set('t', compression => 'pglz');
+SELECT columnar.alter_columnar_table_set('t', compression => 'pglz');
 VACUUM FULL t;
 VACUUM t;
 

--- a/src/test/regress/sql/columnar_zstd.sql
+++ b/src/test/regress/sql/columnar_zstd.sql
@@ -30,7 +30,7 @@ SELECT data_length AS size_comp_level_default FROM columnar.stripe WHERE storage
     SELECT storage_id from columnar_test_helpers.columnar_storage_info('test_zstd')) \gset
 
 -- change compression level
-SELECT alter_columnar_table_set('test_zstd', compression_level => 19);
+SELECT columnar.alter_columnar_table_set('test_zstd', compression_level => 19);
 VACUUM FULL test_zstd;
 
 SELECT data_length AS size_comp_level_19 FROM columnar.stripe WHERE storage_id = (


### PR DESCRIPTION
Add `columnar.` ns to `alter_columnar_table_set` & `alter_columnar_table_reset`. This PR also adjusted the Dockerfile to get `make check-all` to run in a container and added GH Actions as CI.